### PR TITLE
Change check for consented vendors and purposes from OR to AND

### DIFF
--- a/src/vue/components/ConsentManagement/ConsentManagement.test.ts
+++ b/src/vue/components/ConsentManagement/ConsentManagement.test.ts
@@ -31,8 +31,9 @@ describe('ConsentManagement component', () => {
     const wrapper = mount(ConsentManagement, {
       propsData: {
         vendorId: '#1234',
-        purposeIds: ['#1234'],
-        customPurposes: [{ _id: '#1234' }],
+        purposeIds: ['#5678'],
+        customPurposes: [{ _id: '#5678' }],
+        customVendors: [{ _id: '#1234' }],
       },
       slots: {
         onConsent: `<div>Consent</div>`,

--- a/src/vue/components/ConsentManagement/ConsentManagement.vue
+++ b/src/vue/components/ConsentManagement/ConsentManagement.vue
@@ -45,7 +45,7 @@ export default Vue.extend<{}, Methods, {}, Props>({
     },
     hasConsent(): boolean {
       return (
-        this.hasCustomVendorConsent(this.vendorId) || this.purposeIds.some((id) => this.hasCustomPurposeConsent(id))
+        this.hasCustomVendorConsent(this.vendorId) && this.purposeIds.every((id) => this.hasCustomPurposeConsent(id))
       );
     },
   },

--- a/src/vue/components/EmbedFacebookConsent/EmbedFacebookConsent.test.ts
+++ b/src/vue/components/EmbedFacebookConsent/EmbedFacebookConsent.test.ts
@@ -32,30 +32,8 @@ describe('EmbedFacebookConsent component', () => {
     expect(wrapper.element).toMatchSnapshot();
   });
 
-  it('should render the embed in case of a consented vendor', async () => {
+  it('should render the embed in case of a consented vendor and his purpose(s)', async () => {
     store.commit('sourcepoint/setCustomVendorConsents', [{ _id: VENDOR_ID_FACEBOOK }]);
-
-    const wrapper = mount(EmbedFacebookConsent, {
-      propsData: {
-        privacyManagerId: 12345,
-        content: '<div>Facebook Embed Content</div>',
-      },
-      store,
-      localVue,
-    });
-
-    await wrapper.vm.$nextTick();
-
-    expect(wrapper.element).toMatchInlineSnapshot(`
-      <div>
-        <div>
-          Facebook Embed Content
-        </div>
-      </div>
-    `);
-  });
-
-  it('should render the embed in case of a consented purpose', async () => {
     store.commit('sourcepoint/setCustomPurposeConsents', [{ _id: PURPOSE_ID_SOCIAL }]);
 
     const wrapper = mount(EmbedFacebookConsent, {

--- a/src/vue/components/EmbedInstagramConsent/EmbedInstagramConsent.test.ts
+++ b/src/vue/components/EmbedInstagramConsent/EmbedInstagramConsent.test.ts
@@ -32,30 +32,8 @@ describe('EmbedInstagramConsent component', () => {
     expect(wrapper.element).toMatchSnapshot();
   });
 
-  it('should render the embed in case of a consented vendor', async () => {
+  it('should render the embed in case of a consented vendor and his purpose(s)', async () => {
     store.commit('sourcepoint/setCustomVendorConsents', [{ _id: VENDOR_ID_INSTAGRAM }]);
-
-    const wrapper = mount(EmbedInstagramConsent, {
-      propsData: {
-        privacyManagerId: 12345,
-        content: '<div>Instagram Embed Content</div>',
-      },
-      store,
-      localVue,
-    });
-
-    await wrapper.vm.$nextTick();
-
-    expect(wrapper.element).toMatchInlineSnapshot(`
-      <div>
-        <div>
-          Instagram Embed Content
-        </div>
-      </div>
-    `);
-  });
-
-  it('should render the embed in case of a consented purpose', async () => {
     store.commit('sourcepoint/setCustomPurposeConsents', [{ _id: PURPOSE_ID_SOCIAL }]);
 
     const wrapper = mount(EmbedInstagramConsent, {

--- a/src/vue/components/EmbedTwitterConsent/EmbedTwitterConsent.test.ts
+++ b/src/vue/components/EmbedTwitterConsent/EmbedTwitterConsent.test.ts
@@ -32,30 +32,8 @@ describe('EmbedTwitterConsent component', () => {
     expect(wrapper.element).toMatchSnapshot();
   });
 
-  it('should render the embed in case of a consented vendor', async () => {
+  it('should render the embed in case of a consented vendor and consented purpose(s)', async () => {
     store.commit('sourcepoint/setCustomVendorConsents', [{ _id: VENDOR_ID_TWITTER }]);
-
-    const wrapper = mount(EmbedTwitterConsent, {
-      propsData: {
-        privacyManagerId: 12345,
-        content: '<div>Twitter Embed Content</div>',
-      },
-      store,
-      localVue,
-    });
-
-    await wrapper.vm.$nextTick();
-
-    expect(wrapper.element).toMatchInlineSnapshot(`
-      <div>
-        <div>
-          Twitter Embed Content
-        </div>
-      </div>
-    `);
-  });
-
-  it('should render the embed in case of a consented purpose', async () => {
     store.commit('sourcepoint/setCustomPurposeConsents', [{ _id: PURPOSE_ID_SOCIAL }]);
 
     const wrapper = mount(EmbedTwitterConsent, {

--- a/src/vue/components/EmbedYoutubeConsent/EmbedYoutubeConsent.test.ts
+++ b/src/vue/components/EmbedYoutubeConsent/EmbedYoutubeConsent.test.ts
@@ -32,28 +32,8 @@ describe('EmbedYoutubeConsent component', () => {
     expect(wrapper.element).toMatchSnapshot();
   });
 
-  it('should render the embed in case of a consented vendor', () => {
+  it('should render the embed in case of a consented vendor and his purpose(s)', () => {
     store.commit('sourcepoint/setCustomVendorConsents', [{ _id: VENDOR_ID_YOUTUBE }]);
-
-    const wrapper = mount(EmbedYoutubeConsent, {
-      propsData: {
-        privacyManagerId: 12345,
-        content: '<div>Youtube Embed Content</div>',
-      },
-      store,
-      localVue,
-    });
-
-    expect(wrapper.element).toMatchInlineSnapshot(`
-      <div>
-        <div>
-          Youtube Embed Content
-        </div>
-      </div>
-    `);
-  });
-
-  it('should render the embed in case of a consented purpose', () => {
     store.commit('sourcepoint/setCustomPurposeConsents', [{ _id: PURPOSE_ID_SOCIAL }]);
 
     const wrapper = mount(EmbedYoutubeConsent, {


### PR DESCRIPTION
Previously, to render an embed, it was sufficient that only the vendor or a purpose had consent.
But in terms of data protection, this behavior is not valid.

With this pull request, consents have to be given **to a vendor and all of its purposes** to render an embed.