### PR TITLE
Add new function `postCustomConsent` to give consents programmatically

### DIFF
--- a/src/sourcepoint/README.md
+++ b/src/sourcepoint/README.md
@@ -14,6 +14,20 @@ getCustomVendorConsents().then(result => console.log(result)).catch(error => con
 ```    
 </details>
 
+### `postCustomConsent({vendorIds?: string[], purposeIds?: string[], legitimateInterestIds?: string[]}): Promise<PostCustomConsentResult | null>;`
+
+Function to give consents to vendors, purposes or legitimate interests programmatically.
+
+<details>
+<summary>Example</summary>
+    
+```javascript
+import { postCustomConsent } from '@spring-media/red-sourcepoint-cmp/dist/esm/sourcepoint';
+
+postCustomConsent({vendorIds: [], purposeIds: [], legitimateInterestIds: []}).then(result => console.log(result)).catch(error => console.error(error));
+```    
+</details>
+
 ### `customVendorHasConsent(vendor: Consent): Promise<boolean>;`
 
 Checks whether the user has consented to given vendor.

--- a/src/sourcepoint/index.test.ts
+++ b/src/sourcepoint/index.test.ts
@@ -15,6 +15,7 @@ describe('sourcepoint index', () => {
       'loadPrivacyManagerModal',
       'createConfig',
       'getCustomVendorConsents',
+      'postCustomConsent',
     ]);
   });
 });

--- a/src/sourcepoint/index.ts
+++ b/src/sourcepoint/index.ts
@@ -4,3 +4,4 @@ export * from './has-custom-consent';
 export * from './privacy-manager';
 export * from './create-config';
 export * from './get-custom-vendor-consents';
+export * from './post-custom-consent';

--- a/src/sourcepoint/post-custom-consent.node.test.ts
+++ b/src/sourcepoint/post-custom-consent.node.test.ts
@@ -1,0 +1,13 @@
+/**
+ * @jest-environment node
+ */
+
+import { postCustomConsent } from './post-custom-consent';
+
+describe('postCustomConsent', () => {
+  it('should reject if window is not present', async () => {
+    expect.assertions(1);
+
+    await expect(postCustomConsent({})).rejects.toBe(undefined);
+  });
+});

--- a/src/sourcepoint/post-custom-consent.test.ts
+++ b/src/sourcepoint/post-custom-consent.test.ts
@@ -1,0 +1,52 @@
+import { postCustomConsent } from './post-custom-consent';
+
+describe('postCustomConsent', () => {
+  it('should call the __tcfapi function', () => {
+    window.__tcfapi = jest.fn();
+
+    const vendorIds = ['1234'];
+    const purposeIds = ['5678'];
+    const legitimateInterestIds = ['9012'];
+
+    postCustomConsent({ vendorIds, purposeIds, legitimateInterestIds });
+
+    expect(window.__tcfapi).toHaveBeenCalledWith(
+      'postCustomConsent',
+      2,
+      expect.any(Function),
+      vendorIds,
+      purposeIds,
+      legitimateInterestIds,
+    );
+
+    delete window.__tcfapi;
+  });
+
+  it('should reject the command if the success parameter of the callback is false', async () => {
+    window.__tcfapi = (_command: string, _version: number, callback: Function): void => {
+      callback(null, false);
+    };
+
+    await expect(postCustomConsent({})).rejects.toBe(null);
+
+    delete window.__tcfapi;
+  });
+
+  it('should resolve the command with the expected result', async () => {
+    const result = {};
+
+    window.__tcfapi = (_command: string, _version: number, callback: Function): void => {
+      callback(result, true);
+    };
+
+    await expect(postCustomConsent({})).resolves.toBe(result);
+
+    delete window.__tcfapi;
+  });
+
+  it('should reject if the __tcfapi function is not present', async () => {
+    expect.assertions(1);
+
+    await expect(postCustomConsent({})).rejects.toBe(undefined);
+  });
+});

--- a/src/sourcepoint/post-custom-consent.ts
+++ b/src/sourcepoint/post-custom-consent.ts
@@ -1,0 +1,28 @@
+import { PostCustomConsentPayload, PostCustomConsentResult } from './typings';
+
+export const postCustomConsent = ({
+  vendorIds = [],
+  purposeIds = [],
+  legitimateInterestIds = [],
+}: PostCustomConsentPayload): Promise<PostCustomConsentResult | null> => {
+  return new Promise((resolve, reject) => {
+    if (typeof window === 'undefined' || !window.__tcfapi) {
+      return reject();
+    }
+
+    window.__tcfapi(
+      'postCustomConsent',
+      2,
+      (data: PostCustomConsentResult | null, success: boolean) => {
+        if (!success) {
+          return reject(data);
+        }
+
+        resolve(data);
+      },
+      vendorIds,
+      purposeIds,
+      legitimateInterestIds,
+    );
+  });
+};

--- a/src/sourcepoint/typings.d.ts
+++ b/src/sourcepoint/typings.d.ts
@@ -16,6 +16,23 @@ export type CustomVendorConsentsResult = {
   consentedVendors: CustomVendor[];
 };
 
+export type PostCustomConsentResult = {
+  categories: string[];
+  consentUUID: string;
+  legIntCategories: string[];
+  rejectAny: boolean;
+  specialFeatures: string[];
+  vendors: string[];
+};
+
+export type PostCustomConsentPayload = {
+  vendorIds?: string[];
+  purposeIds?: string[];
+  legitimateInterestIds?: string[];
+};
+
+export type PostCustomConsentCallback = (data: PostCustomConsentResult | null, success: boolean) => void;
+
 export type Config = {
   accountId: number;
   wrapperAPIOrigin?: string;

--- a/src/tcf-v2/typings.d.ts
+++ b/src/tcf-v2/typings.d.ts
@@ -1,3 +1,5 @@
+import { PostCustomConsentCallback } from '../sourcepoint/typings';
+
 export type TCDataEventStatus = 'tcloaded' | 'cmpuishown' | 'useractioncomplete';
 
 export type CMPStatus = 'stub' | 'loading' | 'loaded' | 'error';
@@ -27,6 +29,16 @@ export interface TCFV2API {
   (command: 'removeEventListener', version: 2, callback: RemoveEventListenerCallback, listenerId: ListenerId): void;
   (command: 'getTCData', version: 2, callback: GetTCDataCallback, vendorIds?: number[]): void;
   (command: 'ping', version: 2, callback: PingCallback): void;
+
+  // additional Sourcepoint commands
+  (
+    command: 'postCustomConsent',
+    version: 2,
+    callback: PostCustomConsentCallback,
+    vendorIds: string[],
+    purposeIds: string[],
+    legitimateInterestIds: string[],
+  ): void;
 }
 
 export interface PingReturn {


### PR DESCRIPTION
This PR adds a new function to give consents for custom vendors, purposes and legitimate interests programmatically.