### PR TITLE
Implement new component to give consents programmatically

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Pull Request Check
 
 on: pull_request
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "CMP (Content Management Platform) implementation for www.bild.de using the Sourcepoint API",
   "scripts": {
     "test": "jest --config tests/jest.config.js",
-    "test:cae:package": "jest tests/cae-files.test.js && es-check es5 .cae/*.js",
+    "test:cae:files": "jest tests/cae-files.test.js",
+    "test:cae:package": "npm run test:cae:files && es-check es5 .cae/*.js",
     "test:all": "npm run build && npm run test && npm run test:cae:package",
     "build": "rollup -c",
     "postbuild": "npm run build:cae:package",

--- a/src/vue/components/ConsentActions/ConsentActions.test.ts
+++ b/src/vue/components/ConsentActions/ConsentActions.test.ts
@@ -47,7 +47,7 @@ describe('ConsentActions component', () => {
     });
 
     it('should dispatch an (vuex) action to update the consents in the store', () => {
-      expect.assertions(2);
+      expect.assertions(3);
 
       const localVue = createLocalVue();
       localVue.use(Vuex);
@@ -56,6 +56,7 @@ describe('ConsentActions component', () => {
       const store = new Vuex.Store({
         modules: {
           sourcepoint: {
+            namespaced: true,
             actions: {
               bootstrapConsents: bootstrapSpy,
             },

--- a/src/vue/components/ConsentActions/ConsentActions.test.ts
+++ b/src/vue/components/ConsentActions/ConsentActions.test.ts
@@ -1,0 +1,87 @@
+import { mount, createLocalVue } from '@vue/test-utils';
+import Vuex from 'vuex';
+import { postCustomConsent } from '../../../sourcepoint';
+import { ConsentActions } from './';
+
+jest.mock('../../../sourcepoint');
+
+describe('ConsentActions component', () => {
+  it('should provide a default scoped slot', () => {
+    const wrapper = mount(ConsentActions, {
+      slots: {
+        default: '<div>default slot</div>',
+      },
+    });
+
+    expect(wrapper.element).toMatchInlineSnapshot(`
+      <div>
+        default slot
+      </div>
+    `);
+  });
+
+  it('should not break if no slot is used', () => {
+    expect(mount(ConsentActions).element).toMatchInlineSnapshot(`<!---->`);
+  });
+
+  describe('slot function consentCustomPurpose', () => {
+    it('should handle an error case as expected', () => {
+      expect.assertions(2);
+
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      (postCustomConsent as jest.Mock).mockImplementationOnce(() => Promise.reject(null));
+
+      mount(ConsentActions, {
+        scopedSlots: {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          async default({ consentCustomPurpose }: { consentCustomPurpose: (id: string) => void }): Promise<void> {
+            await consentCustomPurpose('1234');
+
+            expect(postCustomConsent).toHaveBeenCalledWith({ purposeIds: ['1234'] });
+            expect(consoleSpy).toHaveBeenCalled();
+
+            consoleSpy.mockRestore();
+          },
+        },
+      });
+    });
+
+    it('should dispatch an (vuex) action to update the consents in the store', () => {
+      expect.assertions(2);
+
+      const localVue = createLocalVue();
+      localVue.use(Vuex);
+
+      const bootstrapSpy = jest.fn();
+      const store = new Vuex.Store({
+        modules: {
+          sourcepoint: {
+            actions: {
+              bootstrapConsents: bootstrapSpy,
+            },
+          },
+        },
+      });
+
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      (postCustomConsent as jest.Mock).mockImplementationOnce(() => Promise.resolve({}));
+
+      mount(ConsentActions, {
+        scopedSlots: {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          async default({ consentCustomPurpose }: { consentCustomPurpose: (id: string) => void }): Promise<void> {
+            await consentCustomPurpose('1234');
+
+            expect(postCustomConsent).toHaveBeenCalledWith({ purposeIds: ['1234'] });
+            expect(consoleSpy).not.toHaveBeenCalled();
+            expect(bootstrapSpy).toHaveBeenCalled();
+
+            consoleSpy.mockRestore();
+          },
+        },
+        localVue,
+        store,
+      });
+    });
+  });
+});

--- a/src/vue/components/ConsentActions/ConsentActions.vue
+++ b/src/vue/components/ConsentActions/ConsentActions.vue
@@ -1,0 +1,37 @@
+<script lang="ts">
+import Vue from 'vue';
+import { mapActions } from 'vuex';
+import { postCustomConsent } from '../../../sourcepoint';
+import { PostCustomConsentPayload } from '../../../sourcepoint/typings';
+
+type Methods = {
+  customConsent(payload: PostCustomConsentPayload): Promise<void>;
+  refreshConsents(): void;
+};
+
+export default Vue.extend<{}, Methods, {}, {}>({
+  name: 'ConsentActions',
+  methods: {
+    ...mapActions({ refreshConsents: 'sourcepoint/bootstrapConsents' }),
+    async customConsent(payload: PostCustomConsentPayload) {
+      try {
+        await postCustomConsent(payload);
+      } catch (e) {
+        console.error('Could not create custom consent.');
+        return;
+      }
+
+      this.refreshConsents();
+    },
+  },
+  render() {
+    return (
+      this.$scopedSlots.default &&
+      (this.$scopedSlots.default({
+        consentCustomPurpose: (id: string) => this.customConsent({ purposeIds: [id] }),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      }) as any)
+    );
+  },
+});
+</script>

--- a/src/vue/components/ConsentActions/README.md
+++ b/src/vue/components/ConsentActions/README.md
@@ -1,0 +1,34 @@
+# ConsentActions Component
+
+The ConsentActions component is a renderless component which provides methods to give consents programmatically.
+
+## API
+
+### Slots
+
+#### default
+
+| Slot Props           | Signature          | 
+| ---------------------|------------------- |
+| consentCustomPurpose | (id: string): void |
+
+## Example
+
+```vue
+<template>
+  <div>
+    <consent-actions v-slot="{ consentCustomPurpose }">
+      <button @click="consentCustomPurpose(purposeId)">Consent Custom Purpose</button>
+    </consent-actions>
+  </div>
+</template>
+
+<script>
+import { ConsentActions } from '@spring-media/red-sourcepoint-cmp/dist/esm/vue/components';
+
+export default {
+  data: () => ({ purposeId: 1234 }),
+  components: { ConsentActions }
+}
+</script>
+```

--- a/src/vue/components/ConsentActions/index.ts
+++ b/src/vue/components/ConsentActions/index.ts
@@ -1,0 +1,1 @@
+export { default as ConsentActions } from './ConsentActions.vue';

--- a/src/vue/components/EmbedFacebookConsent/EmbedFacebookConsent.test.ts
+++ b/src/vue/components/EmbedFacebookConsent/EmbedFacebookConsent.test.ts
@@ -55,25 +55,4 @@ describe('EmbedFacebookConsent component', () => {
       </div>
     `);
   });
-
-  it('should load the privacy manager', () => {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore
-    window._sp_ = {
-      loadPrivacyManagerModal: jest.fn(),
-    };
-
-    const wrapper = mount(EmbedFacebookConsent, {
-      propsData: {
-        privacyManagerId: 12345,
-        content: '<div>Facebook Embed Content</div>',
-      },
-      store,
-      localVue,
-    });
-
-    wrapper.find('.embed-placeholder__button').trigger('click');
-
-    expect(window._sp_.loadPrivacyManagerModal).toHaveBeenCalledWith(12345);
-  });
 });

--- a/src/vue/components/EmbedFacebookConsent/__snapshots__/EmbedFacebookConsent.test.ts.snap
+++ b/src/vue/components/EmbedFacebookConsent/__snapshots__/EmbedFacebookConsent.test.ts.snap
@@ -89,8 +89,8 @@ exports[`EmbedFacebookConsent component should render the placeholder by default
     class="embed-placeholder__button"
   >
     
-        Soziale Netzwerke aktivieren
-      
+          Soziale Netzwerke aktivieren
+        
   </button>
    
   <div

--- a/src/vue/components/EmbedFacebookPlaceholder/EmbedFacebookPlaceholder.test.ts
+++ b/src/vue/components/EmbedFacebookPlaceholder/EmbedFacebookPlaceholder.test.ts
@@ -1,46 +1,8 @@
-import Vue from 'vue';
 import { mount } from '@vue/test-utils';
 import { EmbedFacebookPlaceholder } from './';
 
-const loadPrivacyManagerModal = jest.fn();
-
-const privacyManagerStub = Vue.extend({
-  name: 'PrivacyManager',
-  render() {
-    return (
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this.$scopedSlots.default!({
-        loadPrivacyManagerModal,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      }) as any
-    );
-  },
-});
-
 describe('EmbedFacebookPlaceholder', () => {
-  afterEach(() => {
-    loadPrivacyManagerModal.mockReset();
-  });
-
   it('should render without any errors', () => {
     expect(mount(EmbedFacebookPlaceholder, { propsData: { privacyManagerId: 12345 } }).element).toMatchSnapshot();
-  });
-
-  describe('should open a privacy manager by clicking on', () => {
-    it.each([
-      ['the "activate consent" button', '.embed-placeholder__button'],
-      ['the link to the description', '.embed-placeholder__link-description'],
-      ['the link to the vendor list', '.embed-placeholder__link-vendor-list'],
-    ])('%s', (_, selector) => {
-      const wrapper = mount(EmbedFacebookPlaceholder, {
-        stubs: { PrivacyManager: privacyManagerStub },
-        propsData: { privacyManagerId: 12345 },
-      });
-
-      wrapper.find(selector).trigger('click');
-
-      expect(loadPrivacyManagerModal).toHaveBeenCalledWith(12345);
-      expect(loadPrivacyManagerModal).toHaveBeenCalledTimes(1);
-    });
   });
 });

--- a/src/vue/components/EmbedFacebookPlaceholder/__snapshots__/EmbedFacebookPlaceholder.test.ts.snap
+++ b/src/vue/components/EmbedFacebookPlaceholder/__snapshots__/EmbedFacebookPlaceholder.test.ts.snap
@@ -89,8 +89,8 @@ exports[`EmbedFacebookPlaceholder should render without any errors 1`] = `
     class="embed-placeholder__button"
   >
     
-        Soziale Netzwerke aktivieren
-      
+          Soziale Netzwerke aktivieren
+        
   </button>
    
   <div

--- a/src/vue/components/EmbedInstagramConsent/EmbedInstagramConsent.test.ts
+++ b/src/vue/components/EmbedInstagramConsent/EmbedInstagramConsent.test.ts
@@ -55,25 +55,4 @@ describe('EmbedInstagramConsent component', () => {
       </div>
     `);
   });
-
-  it('should load the privacy manager', () => {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore
-    window._sp_ = {
-      loadPrivacyManagerModal: jest.fn(),
-    };
-
-    const wrapper = mount(EmbedInstagramConsent, {
-      propsData: {
-        privacyManagerId: 12345,
-        content: '<div>Instagram Embed Content</div>',
-      },
-      store,
-      localVue,
-    });
-
-    wrapper.find('.embed-placeholder__button').trigger('click');
-
-    expect(window._sp_.loadPrivacyManagerModal).toHaveBeenCalledWith(12345);
-  });
 });

--- a/src/vue/components/EmbedInstagramConsent/__snapshots__/EmbedInstagramConsent.test.ts.snap
+++ b/src/vue/components/EmbedInstagramConsent/__snapshots__/EmbedInstagramConsent.test.ts.snap
@@ -77,8 +77,8 @@ exports[`EmbedInstagramConsent component should render the placeholder by defaul
     class="embed-placeholder__button"
   >
     
-        Soziale Netzwerke aktivieren
-      
+          Soziale Netzwerke aktivieren
+        
   </button>
    
   <div

--- a/src/vue/components/EmbedInstagramPlaceholder/EmbedInstagramPlaceholder.test.ts
+++ b/src/vue/components/EmbedInstagramPlaceholder/EmbedInstagramPlaceholder.test.ts
@@ -1,46 +1,8 @@
-import Vue from 'vue';
 import { mount } from '@vue/test-utils';
 import { EmbedInstagramPlaceholder } from './';
 
-const loadPrivacyManagerModal = jest.fn();
-
-const privacyManagerStub = Vue.extend({
-  name: 'PrivacyManager',
-  render() {
-    return (
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this.$scopedSlots.default!({
-        loadPrivacyManagerModal,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      }) as any
-    );
-  },
-});
-
 describe('EmbedInstagramPlaceholder', () => {
-  afterEach(() => {
-    loadPrivacyManagerModal.mockReset();
-  });
-
   it('should render without any errors', () => {
     expect(mount(EmbedInstagramPlaceholder, { propsData: { privacyManagerId: 12345 } }).element).toMatchSnapshot();
-  });
-
-  describe('should open a privacy manager by clicking on', () => {
-    it.each([
-      ['the "activate consent" button', '.embed-placeholder__button'],
-      ['the link to the description', '.embed-placeholder__link-description'],
-      ['the link to the vendor list', '.embed-placeholder__link-vendor-list'],
-    ])('%s', (_, selector) => {
-      const wrapper = mount(EmbedInstagramPlaceholder, {
-        stubs: { PrivacyManager: privacyManagerStub },
-        propsData: { privacyManagerId: 12345 },
-      });
-
-      wrapper.find(selector).trigger('click');
-
-      expect(loadPrivacyManagerModal).toHaveBeenCalledWith(12345);
-      expect(loadPrivacyManagerModal).toHaveBeenCalledTimes(1);
-    });
   });
 });

--- a/src/vue/components/EmbedInstagramPlaceholder/__snapshots__/EmbedInstagramPlaceholder.test.ts.snap
+++ b/src/vue/components/EmbedInstagramPlaceholder/__snapshots__/EmbedInstagramPlaceholder.test.ts.snap
@@ -77,8 +77,8 @@ exports[`EmbedInstagramPlaceholder should render without any errors 1`] = `
     class="embed-placeholder__button"
   >
     
-        Soziale Netzwerke aktivieren
-      
+          Soziale Netzwerke aktivieren
+        
   </button>
    
   <div

--- a/src/vue/components/EmbedPlaceholder/EmbedPlaceholder.test.ts
+++ b/src/vue/components/EmbedPlaceholder/EmbedPlaceholder.test.ts
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import { mount } from '@vue/test-utils';
 import { EmbedPlaceholder } from './';
+import { PURPOSE_ID_SOCIAL } from '../../../vendor-mapping';
 
 const loadPrivacyManagerModal = jest.fn();
 
@@ -17,6 +18,21 @@ const privacyManagerStub = Vue.extend({
   },
 });
 
+const consentCustomPurpose = jest.fn();
+
+const consentActionsStub = Vue.extend({
+  name: 'ConsentActions',
+  render() {
+    return (
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      this.$scopedSlots.default!({
+        consentCustomPurpose,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      }) as any
+    );
+  },
+});
+
 describe('EmbedPlaceholder', () => {
   afterEach(() => {
     loadPrivacyManagerModal.mockReset();
@@ -26,9 +42,19 @@ describe('EmbedPlaceholder', () => {
     expect(mount(EmbedPlaceholder, { propsData: { privacyManagerId: 12345 } }).element).toMatchSnapshot();
   });
 
+  it('should give a consent to the purpose social media', () => {
+    const wrapper = mount(EmbedPlaceholder, {
+      stubs: { ConsentActions: consentActionsStub },
+      propsData: { privacyManagerId: 1234 },
+    });
+
+    wrapper.find('.embed-placeholder__button').trigger('click');
+
+    expect(consentCustomPurpose).toHaveBeenCalledWith(PURPOSE_ID_SOCIAL);
+  });
+
   describe('should open a privacy manager by clicking on', () => {
     it.each([
-      ['the "activate consent" button', '.embed-placeholder__button'],
       ['the link to the description', '.embed-placeholder__link-description'],
       ['the link to the vendor list', '.embed-placeholder__link-vendor-list'],
     ])('%s', (_, selector) => {

--- a/src/vue/components/EmbedPlaceholder/EmbedPlaceholder.vue
+++ b/src/vue/components/EmbedPlaceholder/EmbedPlaceholder.vue
@@ -25,9 +25,11 @@
         </slot>
       </div>
       <slot name="button">
-        <button class="embed-placeholder__button" @click.prevent="loadPrivacyManagerModal(privacyManagerId)">
-          Soziale Netzwerke aktivieren
-        </button>
+        <consent-actions v-slot="{ consentCustomPurpose }">
+          <button class="embed-placeholder__button" @click.prevent="consentCustomPurpose(socialPurposeId)">
+            Soziale Netzwerke aktivieren
+          </button>
+        </consent-actions>
       </slot>
       <div class="embed-placeholder__footer-text">
         <slot name="footer">
@@ -59,14 +61,23 @@
 <script lang="ts">
 import Vue from 'vue';
 import { PrivacyManager } from '../PrivacyManager';
+import { ConsentActions } from '../ConsentActions';
+import { PURPOSE_ID_SOCIAL } from '../../../vendor-mapping';
 
 type Props = {
   privacyManagerId: number;
 };
 
-export default Vue.extend<{}, {}, {}, Props>({
+type Data = {
+  socialPurposeId: string;
+};
+
+export default Vue.extend<Data, {}, {}, Props>({
   name: 'EmbedPlaceholder',
-  components: { PrivacyManager },
+  components: { PrivacyManager, ConsentActions },
+  data: () => ({
+    socialPurposeId: PURPOSE_ID_SOCIAL,
+  }),
   props: {
     privacyManagerId: {
       type: Number,

--- a/src/vue/components/EmbedPlaceholder/__snapshots__/EmbedPlaceholder.test.ts.snap
+++ b/src/vue/components/EmbedPlaceholder/__snapshots__/EmbedPlaceholder.test.ts.snap
@@ -80,8 +80,8 @@ exports[`EmbedPlaceholder should render without any errors 1`] = `
     class="embed-placeholder__button"
   >
     
-        Soziale Netzwerke aktivieren
-      
+          Soziale Netzwerke aktivieren
+        
   </button>
    
   <div

--- a/src/vue/components/EmbedTwitterConsent/EmbedTwitterConsent.test.ts
+++ b/src/vue/components/EmbedTwitterConsent/EmbedTwitterConsent.test.ts
@@ -55,25 +55,4 @@ describe('EmbedTwitterConsent component', () => {
       </div>
     `);
   });
-
-  it('should load the privacy manager', () => {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore
-    window._sp_ = {
-      loadPrivacyManagerModal: jest.fn(),
-    };
-
-    const wrapper = mount(EmbedTwitterConsent, {
-      propsData: {
-        privacyManagerId: 12345,
-        content: '<div>Twitter Embed Content</div>',
-      },
-      store,
-      localVue,
-    });
-
-    wrapper.find('.embed-placeholder__button').trigger('click');
-
-    expect(window._sp_.loadPrivacyManagerModal).toHaveBeenCalledWith(12345);
-  });
 });

--- a/src/vue/components/EmbedTwitterConsent/__snapshots__/EmbedTwitterConsent.test.ts.snap
+++ b/src/vue/components/EmbedTwitterConsent/__snapshots__/EmbedTwitterConsent.test.ts.snap
@@ -89,8 +89,8 @@ exports[`EmbedTwitterConsent component should render the placeholder by default 
     class="embed-placeholder__button"
   >
     
-        Soziale Netzwerke aktivieren
-      
+          Soziale Netzwerke aktivieren
+        
   </button>
    
   <div

--- a/src/vue/components/EmbedTwitterPlaceholder/EmbedTwitterPlaceholder.test.ts
+++ b/src/vue/components/EmbedTwitterPlaceholder/EmbedTwitterPlaceholder.test.ts
@@ -1,46 +1,8 @@
-import Vue from 'vue';
 import { mount } from '@vue/test-utils';
 import { EmbedTwitterPlaceholder } from './';
 
-const loadPrivacyManagerModal = jest.fn();
-
-const privacyManagerStub = Vue.extend({
-  name: 'PrivacyManager',
-  render() {
-    return (
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this.$scopedSlots.default!({
-        loadPrivacyManagerModal,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      }) as any
-    );
-  },
-});
-
 describe('EmbedTwitterPlaceholder', () => {
-  afterEach(() => {
-    loadPrivacyManagerModal.mockReset();
-  });
-
   it('should render without any errors', () => {
     expect(mount(EmbedTwitterPlaceholder, { propsData: { privacyManagerId: 12345 } }).element).toMatchSnapshot();
-  });
-
-  describe('should open a privacy manager by clicking on', () => {
-    it.each([
-      ['the "activate consent" button', '.embed-placeholder__button'],
-      ['the link to the description', '.embed-placeholder__link-description'],
-      ['the link to the vendor list', '.embed-placeholder__link-vendor-list'],
-    ])('%s', (_, selector) => {
-      const wrapper = mount(EmbedTwitterPlaceholder, {
-        stubs: { PrivacyManager: privacyManagerStub },
-        propsData: { privacyManagerId: 12345 },
-      });
-
-      wrapper.find(selector).trigger('click');
-
-      expect(loadPrivacyManagerModal).toHaveBeenCalledWith(12345);
-      expect(loadPrivacyManagerModal).toHaveBeenCalledTimes(1);
-    });
   });
 });

--- a/src/vue/components/EmbedTwitterPlaceholder/__snapshots__/EmbedTwitterPlaceholder.test.ts.snap
+++ b/src/vue/components/EmbedTwitterPlaceholder/__snapshots__/EmbedTwitterPlaceholder.test.ts.snap
@@ -89,8 +89,8 @@ exports[`EmbedTwitterPlaceholder should render without any errors 1`] = `
     class="embed-placeholder__button"
   >
     
-        Soziale Netzwerke aktivieren
-      
+          Soziale Netzwerke aktivieren
+        
   </button>
    
   <div

--- a/src/vue/components/EmbedYoutubeConsent/EmbedYoutubeConsent.test.ts
+++ b/src/vue/components/EmbedYoutubeConsent/EmbedYoutubeConsent.test.ts
@@ -53,25 +53,4 @@ describe('EmbedYoutubeConsent component', () => {
       </div>
     `);
   });
-
-  it('should load the privacy manager', () => {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore
-    window._sp_ = {
-      loadPrivacyManagerModal: jest.fn(),
-    };
-
-    const wrapper = mount(EmbedYoutubeConsent, {
-      propsData: {
-        privacyManagerId: 12345,
-        content: '<div>Youtube Embed Content</div>',
-      },
-      store,
-      localVue,
-    });
-
-    wrapper.find('.embed-placeholder__button').trigger('click');
-
-    expect(window._sp_.loadPrivacyManagerModal).toHaveBeenCalledWith(12345);
-  });
 });

--- a/src/vue/components/EmbedYoutubeConsent/__snapshots__/EmbedYoutubeConsent.test.ts.snap
+++ b/src/vue/components/EmbedYoutubeConsent/__snapshots__/EmbedYoutubeConsent.test.ts.snap
@@ -55,8 +55,8 @@ exports[`EmbedYoutubeConsent component should render the placeholder by default 
     class="embed-placeholder__button"
   >
     
-        Soziale Netzwerke aktivieren
-      
+          Soziale Netzwerke aktivieren
+        
   </button>
    
   <div

--- a/src/vue/components/EmbedYoutubePlaceholder/EmbedYoutubePlaceholder.test.ts
+++ b/src/vue/components/EmbedYoutubePlaceholder/EmbedYoutubePlaceholder.test.ts
@@ -1,46 +1,8 @@
-import Vue from 'vue';
 import { mount } from '@vue/test-utils';
 import { EmbedYoutubePlaceholder } from './';
 
-const loadPrivacyManagerModal = jest.fn();
-
-const privacyManagerStub = Vue.extend({
-  name: 'PrivacyManager',
-  render() {
-    return (
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this.$scopedSlots.default!({
-        loadPrivacyManagerModal,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      }) as any
-    );
-  },
-});
-
 describe('EmbedYoutubePlaceholder', () => {
-  afterEach(() => {
-    loadPrivacyManagerModal.mockReset();
-  });
-
   it('should render without any errors', () => {
     expect(mount(EmbedYoutubePlaceholder, { propsData: { privacyManagerId: 12345 } }).element).toMatchSnapshot();
-  });
-
-  describe('should open a privacy manager by clicking on', () => {
-    it.each([
-      ['the "activate consent" button', '.embed-placeholder__button'],
-      ['the link to the description', '.embed-placeholder__link-description'],
-      ['the link to the vendor list', '.embed-placeholder__link-vendor-list'],
-    ])('%s', (_, selector) => {
-      const wrapper = mount(EmbedYoutubePlaceholder, {
-        stubs: { PrivacyManager: privacyManagerStub },
-        propsData: { privacyManagerId: 12345 },
-      });
-
-      wrapper.find(selector).trigger('click');
-
-      expect(loadPrivacyManagerModal).toHaveBeenCalledWith(12345);
-      expect(loadPrivacyManagerModal).toHaveBeenCalledTimes(1);
-    });
   });
 });

--- a/src/vue/components/EmbedYoutubePlaceholder/__snapshots__/EmbedYoutubePlaceholder.test.ts.snap
+++ b/src/vue/components/EmbedYoutubePlaceholder/__snapshots__/EmbedYoutubePlaceholder.test.ts.snap
@@ -55,8 +55,8 @@ exports[`EmbedYoutubePlaceholder should render without any errors 1`] = `
     class="embed-placeholder__button"
   >
     
-        Soziale Netzwerke aktivieren
-      
+          Soziale Netzwerke aktivieren
+        
   </button>
    
   <div

--- a/tests/__snapshots__/cae-files.test.js.snap
+++ b/tests/__snapshots__/cae-files.test.js.snap
@@ -7,8 +7,8 @@ exports[`Testsuite CAE files red-cmp-embed-facebook-placeholder.html should have
     Um mit Inhalten aus Facebook und anderen Sozialen Netzwerken zu interagieren oder diese darzustellen, brauchen wir
     deine Zustimmung.
   </div> <button class=\\"embed-placeholder__button\\">
-        Soziale Netzwerke aktivieren
-      </button> <div class=\\"embed-placeholder__footer-text\\">
+          Soziale Netzwerke aktivieren
+        </button> <div class=\\"embed-placeholder__footer-text\\">
         Ich bin damit einverstanden, dass mir externe Inhalte aus Sozialen Netzwerken angezeigt werden. Damit können
         personenbezogene Daten an Drittanbieter übermittelt werden. Mehr dazu findest du in der
         <a href=\\"#\\" rel=\\"noopener\\" target=\\"_blank\\" class=\\"embed-placeholder__text-link embed-placeholder__link-description\\">Beschreibung dieses Datenverarbeitungszweck</a>
@@ -24,8 +24,8 @@ exports[`Testsuite CAE files red-cmp-embed-instagram-placeholder.html should hav
     Um mit Inhalten aus Instagram und anderen Sozialen Netzwerken zu interagieren oder diese darzustellen, brauchen
     wir deine Zustimmung.
   </div> <button class=\\"embed-placeholder__button\\">
-        Soziale Netzwerke aktivieren
-      </button> <div class=\\"embed-placeholder__footer-text\\">
+          Soziale Netzwerke aktivieren
+        </button> <div class=\\"embed-placeholder__footer-text\\">
         Ich bin damit einverstanden, dass mir externe Inhalte aus Sozialen Netzwerken angezeigt werden. Damit können
         personenbezogene Daten an Drittanbieter übermittelt werden. Mehr dazu findest du in der
         <a href=\\"#\\" rel=\\"noopener\\" target=\\"_blank\\" class=\\"embed-placeholder__text-link embed-placeholder__link-description\\">Beschreibung dieses Datenverarbeitungszweck</a>
@@ -43,8 +43,8 @@ exports[`Testsuite CAE files red-cmp-embed-placeholder.html should have the expe
         Um mit Inhalten aus Sozialen Netzwerken zu interagieren oder diese darzustellen, brauchen wir deine
         Zustimmung.
       </div> <button class=\\"embed-placeholder__button\\">
-        Soziale Netzwerke aktivieren
-      </button> <div class=\\"embed-placeholder__footer-text\\">
+          Soziale Netzwerke aktivieren
+        </button> <div class=\\"embed-placeholder__footer-text\\">
         Ich bin damit einverstanden, dass mir externe Inhalte aus Sozialen Netzwerken angezeigt werden. Damit können
         personenbezogene Daten an Drittanbieter übermittelt werden. Mehr dazu findest du in der
         <a href=\\"#\\" rel=\\"noopener\\" target=\\"_blank\\" class=\\"embed-placeholder__text-link embed-placeholder__link-description\\">Beschreibung dieses Datenverarbeitungszweck</a>
@@ -60,8 +60,8 @@ exports[`Testsuite CAE files red-cmp-embed-twitter-placeholder.html should have 
     Um mit Inhalten aus Twitter und anderen Sozialen Netzwerken zu interagieren oder diese darzustellen, brauchen wir
     deine Zustimmung.
   </div> <button class=\\"embed-placeholder__button\\">
-        Soziale Netzwerke aktivieren
-      </button> <div class=\\"embed-placeholder__footer-text\\">
+          Soziale Netzwerke aktivieren
+        </button> <div class=\\"embed-placeholder__footer-text\\">
         Ich bin damit einverstanden, dass mir externe Inhalte aus Sozialen Netzwerken angezeigt werden. Damit können
         personenbezogene Daten an Drittanbieter übermittelt werden. Mehr dazu findest du in der
         <a href=\\"#\\" rel=\\"noopener\\" target=\\"_blank\\" class=\\"embed-placeholder__text-link embed-placeholder__link-description\\">Beschreibung dieses Datenverarbeitungszweck</a>
@@ -77,8 +77,8 @@ exports[`Testsuite CAE files red-cmp-embed-youtube-placeholder.html should have 
     Um mit Inhalten aus YouTube und anderen Sozialen Netzwerken zu interagieren oder diese darzustellen, brauchen wir
     deine Zustimmung.
   </div> <button class=\\"embed-placeholder__button\\">
-        Soziale Netzwerke aktivieren
-      </button> <div class=\\"embed-placeholder__footer-text\\">
+          Soziale Netzwerke aktivieren
+        </button> <div class=\\"embed-placeholder__footer-text\\">
         Ich bin damit einverstanden, dass mir externe Inhalte aus Sozialen Netzwerken angezeigt werden. Damit können
         personenbezogene Daten an Drittanbieter übermittelt werden. Mehr dazu findest du in der
         <a href=\\"#\\" rel=\\"noopener\\" target=\\"_blank\\" class=\\"embed-placeholder__text-link embed-placeholder__link-description\\">Beschreibung dieses Datenverarbeitungszweck</a>


### PR DESCRIPTION
This PR implements a new component that can be used to give consents (only for purposes for now) programmatically.

> It also deletes some redundant/duplicated unit tests.

To see it in action do the following steps:
1. add following entry to your hosts file: `127.0.0.1 local.bild.de`
2. checkout the branch
3. run `npm i`
4. run `npm run build`
5. run `npm run playground:prepare`
it will ask you a couple of questions. Just use the values from the screenshot below:   
<img width="635" alt="Bildschirmfoto 2020-05-14 um 18 38 53" src="https://user-images.githubusercontent.com/1788471/81961226-5f429c00-9612-11ea-88e6-93c98b7a9d06.png">

6. run `npm run playground:start`
7. open the prompted url that points to the esm-bundle (http://local.bild.de:5000/build/esm)
8. Click on the "Soziale Netzwerke aktivieren" button in one of the placeholder
All placeholder should be replaced by their social embeds.
9. Grab some drinks and enjoy the day