### PR TITLE
REDO-1090: feat(vue): add postCustomConsent method to social sharing popup

### DIFF
--- a/src/vue/components/SocialSharingPopup/SocialSharingPopup.test.ts
+++ b/src/vue/components/SocialSharingPopup/SocialSharingPopup.test.ts
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import { mount } from '@vue/test-utils';
 import { SocialSharingPopup } from './';
+import { PURPOSE_ID_SOCIAL } from '../../../vendor-mapping';
 
 const loadPrivacyManagerModal = jest.fn();
 
@@ -16,6 +17,21 @@ const privacyManagerStub = Vue.extend({
   },
 });
 
+const consentCustomPurpose = jest.fn();
+
+const consentActionsStub = Vue.extend({
+  name: 'ConsentActions',
+  render() {
+    return (
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      this.$scopedSlots.default!({
+        consentCustomPurpose,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      }) as any
+    );
+  },
+});
+
 describe('SocialSharingPopup', () => {
   afterEach(() => {
     loadPrivacyManagerModal.mockReset();
@@ -25,7 +41,7 @@ describe('SocialSharingPopup', () => {
     expect(mount(SocialSharingPopup, { propsData: { privacyManagerId: 12345 } }).element).toMatchSnapshot();
   });
 
-  it('should be not visible if initialVisibility is set to false', function () {
+  it('should not be visible if initialVisibility is set to false', function () {
     const wrapper = mount(SocialSharingPopup, {
       propsData: { privacyManagerId: 12345, initialVisibility: false },
     });
@@ -33,7 +49,7 @@ describe('SocialSharingPopup', () => {
     expect(wrapper.find('.social-sharing-popup__container').exists()).toBeFalsy();
   });
 
-  it('button click should hide the popup', async () => {
+  it('should hide the popup on button click ', async () => {
     const wrapper = mount(SocialSharingPopup, {
       propsData: { privacyManagerId: 12345, initialVisibility: true },
     });
@@ -52,9 +68,23 @@ describe('SocialSharingPopup', () => {
       propsData: { privacyManagerId: 12345, initialVisibility: true },
     });
 
-    wrapper.find('.social-sharing-popup__button--accept').trigger('click');
+    wrapper.find('.social-sharing-popup__description > a').trigger('click');
 
     expect(loadPrivacyManagerModal).toHaveBeenCalledWith(12345);
     expect(loadPrivacyManagerModal).toHaveBeenCalledTimes(1);
+  });
+
+  it('should give a consent to the purpose social media and close the popup', async () => {
+    const wrapper = mount(SocialSharingPopup, {
+      stubs: { ConsentActions: consentActionsStub },
+      propsData: { privacyManagerId: 12345, initialVisibility: true },
+    });
+
+    wrapper.find('.social-sharing-popup__button--accept').trigger('click');
+
+    expect(consentCustomPurpose).toHaveBeenCalledWith(PURPOSE_ID_SOCIAL);
+
+    await Vue.nextTick();
+    expect(wrapper.element).toMatchSnapshot();
   });
 });

--- a/src/vue/components/SocialSharingPopup/SocialSharingPopup.vue
+++ b/src/vue/components/SocialSharingPopup/SocialSharingPopup.vue
@@ -22,12 +22,14 @@
           >
             Schließen
           </button>
-          <button
-            class="social-sharing-popup__button social-sharing-popup__button--accept"
-            @click.prevent="loadPrivacyManagerModal(privacyManagerId)"
-          >
-            Akzeptieren
-          </button>
+          <consent-actions v-slot="{ consentCustomPurpose }">
+            <button
+              class="social-sharing-popup__button social-sharing-popup__button--accept"
+              @click.prevent="[consentCustomPurpose(socialPurposeId), setVisibility(false)]"
+            >
+              Akzeptieren
+            </button>
+          </consent-actions>
         </div>
       </slot>
     </div>
@@ -37,9 +39,12 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue';
 import { PrivacyManager } from '../PrivacyManager';
+import { ConsentActions } from '../ConsentActions';
+import { PURPOSE_ID_SOCIAL } from '../../../vendor-mapping';
 
 type Data = {
   isVisible: boolean;
+  socialPurposeId: string;
 };
 
 type Methods = {
@@ -53,10 +58,11 @@ type Props = {
 
 export default Vue.extend<Data, Methods, {}, Props>({
   name: 'SocialSharingPopup',
-  components: { PrivacyManager },
-  data(): { isVisible: boolean } {
+  components: { PrivacyManager, ConsentActions },
+  data(): { isVisible: boolean; socialPurposeId: string } {
     return {
       isVisible: this.initialVisibility,
+      socialPurposeId: PURPOSE_ID_SOCIAL,
     };
   },
   props: {

--- a/src/vue/components/SocialSharingPopup/__snapshots__/SocialSharingPopup.test.ts.snap
+++ b/src/vue/components/SocialSharingPopup/__snapshots__/SocialSharingPopup.test.ts.snap
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SocialSharingPopup button click should hide the popup 1`] = `<!---->`;
+exports[`SocialSharingPopup should give a consent to the purpose social media and close the popup 1`] = `<!---->`;
+
+exports[`SocialSharingPopup should hide the popup on button click  1`] = `<!---->`;
 
 exports[`SocialSharingPopup should initially render visible without any errors 1`] = `
 <div
@@ -46,8 +48,8 @@ exports[`SocialSharingPopup should initially render visible without any errors 1
       class="social-sharing-popup__button social-sharing-popup__button--accept"
     >
       
-          Akzeptieren
-        
+            Akzeptieren
+          
     </button>
   </div>
 </div>


### PR DESCRIPTION
adds the method postCustomConsent to the social sharing popup along the lines of the embeds
expands/adjusts the tests

I'm not sure, if it would be better or even necessary to use a timeout after setting the social purpose consent and before closing the popup.