### PR TITLE
Implement postCustomConsent in es5 playground application

### DIFF
--- a/playground/apps/browser-bundle.js
+++ b/playground/apps/browser-bundle.js
@@ -26,7 +26,7 @@ import './common.css';
       const vendorId = lib.getCustomVendor(vendorName);
 
       if (
-        lib.hasCustomConsentById(vendorId, consentedVendors) ||
+        lib.hasCustomConsentById(vendorId, consentedVendors) &&
         lib.hasCustomConsentById(lib.PURPOSE_ID_SOCIAL, consentedPurposes)
       ) {
         const container = element.querySelector(':scope > div:first-child:not(.processed)');
@@ -60,9 +60,18 @@ import './common.css';
     }
   });
 
-  document.addEventListener('click', (event) => {
-    if (event.target.classList.contains('embed-placeholder__button')) {
+  document.addEventListener('click', async (event) => {
+    if (event.target.classList.contains('open-privacy-manager')) {
       lib.loadPrivacyManagerModal(window.__playground__.parameters.privacyManagerId);
+    }
+
+    if (
+      event.target.classList.contains('embed-placeholder__button') &&
+      !event.target.classList.contains('open-privacy-manager')
+    ) {
+      await lib.postCustomConsent({ purposeIds: [lib.PURPOSE_ID_SOCIAL] });
+
+      checkConsents();
     }
   });
 

--- a/playground/scripts/compile.js
+++ b/playground/scripts/compile.js
@@ -24,7 +24,7 @@ const browserTemplate = () => {
 
   return `
     <div>
-        <div class="privacy-manager__container"><button class="embed-placeholder__button" style="border-radius: 0;" @click="openPrivacyManager">Open Privacy Manager</button></div>
+        <div class="privacy-manager__container"><button class="embed-placeholder__button open-privacy-manager" style="border-radius: 0;" @click="openPrivacyManager">Open Privacy Manager</button></div>
         <ul class="embed__container">
             <li class="embed__item" data-vendor-name="facebook">
                 <div>${facebookPlaceholder}</div>


### PR DESCRIPTION
This PR implements the new postCustomConsent function into es5 playground application to give a consent for a purpose programmatically.