### PR TITLE
Implement a new method "customConsent"

### DIFF
--- a/playground/scripts/compile.js
+++ b/playground/scripts/compile.js
@@ -152,7 +152,7 @@ const compile = async (parameters) => {
         {
           resolveId(source) {
             if (source === 'cmp-embed-placeholder.css') {
-              return `.cae/red-cmp-embed-placeholder-${version}.min.css`;
+              return `.cae/red-cmp-components-${version}.min.css`;
             }
 
             return null;

--- a/src/vue/components/ConsentActions/ConsentActions.test.ts
+++ b/src/vue/components/ConsentActions/ConsentActions.test.ts
@@ -2,10 +2,15 @@ import { mount, createLocalVue } from '@vue/test-utils';
 import Vuex from 'vuex';
 import { postCustomConsent } from '../../../sourcepoint';
 import { ConsentActions } from './';
+import { PostCustomConsentPayload } from '../../../sourcepoint/typings';
 
 jest.mock('../../../sourcepoint');
 
 describe('ConsentActions component', () => {
+  afterEach(() => {
+    (postCustomConsent as jest.Mock).mockReset();
+  });
+
   it('should provide a default scoped slot', () => {
     const wrapper = mount(ConsentActions, {
       slots: {
@@ -33,7 +38,6 @@ describe('ConsentActions component', () => {
 
       mount(ConsentActions, {
         scopedSlots: {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           async default({ consentCustomPurpose }: { consentCustomPurpose: (id: string) => void }): Promise<void> {
             await consentCustomPurpose('1234');
 
@@ -69,7 +73,6 @@ describe('ConsentActions component', () => {
 
       mount(ConsentActions, {
         scopedSlots: {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           async default({ consentCustomPurpose }: { consentCustomPurpose: (id: string) => void }): Promise<void> {
             await consentCustomPurpose('1234');
 
@@ -82,6 +85,29 @@ describe('ConsentActions component', () => {
         },
         localVue,
         store,
+      });
+    });
+  });
+
+  describe('slot function customConsent', () => {
+    it('should call postCustomConsent with the expected parameters', () => {
+      expect.assertions(1);
+
+      (postCustomConsent as jest.Mock).mockImplementationOnce(() => Promise.reject(null));
+
+      mount(ConsentActions, {
+        scopedSlots: {
+          async default({
+            customConsent,
+          }: {
+            customConsent: (payload: PostCustomConsentPayload) => void;
+          }): Promise<void> {
+            const payload: PostCustomConsentPayload = { vendorIds: ['123'], purposeIds: ['456'] };
+            await customConsent(payload);
+
+            expect(postCustomConsent).toHaveBeenCalledWith(payload);
+          },
+        },
       });
     });
   });

--- a/src/vue/components/ConsentActions/ConsentActions.vue
+++ b/src/vue/components/ConsentActions/ConsentActions.vue
@@ -28,7 +28,8 @@ export default Vue.extend<{}, Methods, {}, {}>({
     return (
       this.$scopedSlots.default &&
       (this.$scopedSlots.default({
-        consentCustomPurpose: (id: string) => this.customConsent({ purposeIds: [id] }),
+        consentCustomPurpose: (id: string): Promise<void> => this.customConsent({ purposeIds: [id] }),
+        customConsent: (payload: PostCustomConsentPayload): Promise<void> => this.customConsent(payload),
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       }) as any)
     );

--- a/src/vue/components/EmbedPlaceholder/EmbedPlaceholder.test.ts
+++ b/src/vue/components/EmbedPlaceholder/EmbedPlaceholder.test.ts
@@ -1,7 +1,13 @@
 import Vue from 'vue';
 import { mount } from '@vue/test-utils';
 import { EmbedPlaceholder } from './';
-import { PURPOSE_ID_SOCIAL } from '../../../vendor-mapping';
+import {
+  PURPOSE_ID_SOCIAL,
+  VENDOR_ID_FACEBOOK,
+  VENDOR_ID_INSTAGRAM,
+  VENDOR_ID_TWITTER,
+  VENDOR_ID_YOUTUBE,
+} from '../../../vendor-mapping';
 
 const loadPrivacyManagerModal = jest.fn();
 
@@ -18,7 +24,7 @@ const privacyManagerStub = Vue.extend({
   },
 });
 
-const consentCustomPurpose = jest.fn();
+const customConsent = jest.fn();
 
 const consentActionsStub = Vue.extend({
   name: 'ConsentActions',
@@ -26,7 +32,7 @@ const consentActionsStub = Vue.extend({
     return (
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       this.$scopedSlots.default!({
-        consentCustomPurpose,
+        customConsent,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       }) as any
     );
@@ -50,7 +56,10 @@ describe('EmbedPlaceholder', () => {
 
     wrapper.find('.embed-placeholder__button').trigger('click');
 
-    expect(consentCustomPurpose).toHaveBeenCalledWith(PURPOSE_ID_SOCIAL);
+    expect(customConsent).toHaveBeenCalledWith({
+      vendorIds: [VENDOR_ID_FACEBOOK, VENDOR_ID_INSTAGRAM, VENDOR_ID_TWITTER, VENDOR_ID_YOUTUBE],
+      purposeIds: [PURPOSE_ID_SOCIAL],
+    });
   });
 
   describe('should open a privacy manager by clicking on', () => {

--- a/src/vue/components/EmbedPlaceholder/EmbedPlaceholder.vue
+++ b/src/vue/components/EmbedPlaceholder/EmbedPlaceholder.vue
@@ -26,7 +26,7 @@
       </div>
       <slot name="button">
         <consent-actions v-slot="{ customConsent }">
-          <button class="embed-placeholder__button" @click.prevent="customConsent(getCustomConsentPayload())">
+          <button class="embed-placeholder__button" @click.prevent="customConsent(customConsents)">
             Soziale Netzwerke aktivieren
           </button>
         </consent-actions>
@@ -76,24 +76,22 @@ type Props = {
 };
 
 type Data = {
-  socialPurposeId: string;
+  customConsents: PostCustomConsentPayload;
 };
 
 export default Vue.extend<Data, {}, {}, Props>({
   name: 'EmbedPlaceholder',
   components: { PrivacyManager, ConsentActions },
+  data: () => ({
+    customConsents: {
+      purposeIds: [PURPOSE_ID_SOCIAL],
+      vendorIds: [VENDOR_ID_FACEBOOK, VENDOR_ID_INSTAGRAM, VENDOR_ID_TWITTER, VENDOR_ID_YOUTUBE],
+    },
+  }),
   props: {
     privacyManagerId: {
       type: Number,
       required: true,
-    },
-  },
-  methods: {
-    getCustomConsentPayload(): PostCustomConsentPayload {
-      return {
-        purposeIds: [PURPOSE_ID_SOCIAL],
-        vendorIds: [VENDOR_ID_FACEBOOK, VENDOR_ID_INSTAGRAM, VENDOR_ID_TWITTER, VENDOR_ID_YOUTUBE],
-      };
     },
   },
 });

--- a/src/vue/components/EmbedPlaceholder/EmbedPlaceholder.vue
+++ b/src/vue/components/EmbedPlaceholder/EmbedPlaceholder.vue
@@ -25,8 +25,8 @@
         </slot>
       </div>
       <slot name="button">
-        <consent-actions v-slot="{ consentCustomPurpose }">
-          <button class="embed-placeholder__button" @click.prevent="consentCustomPurpose(socialPurposeId)">
+        <consent-actions v-slot="{ customConsent }">
+          <button class="embed-placeholder__button" @click.prevent="customConsent(getCustomConsentPayload())">
             Soziale Netzwerke aktivieren
           </button>
         </consent-actions>
@@ -62,7 +62,14 @@
 import Vue from 'vue';
 import { PrivacyManager } from '../PrivacyManager';
 import { ConsentActions } from '../ConsentActions';
-import { PURPOSE_ID_SOCIAL } from '../../../vendor-mapping';
+import {
+  PURPOSE_ID_SOCIAL,
+  VENDOR_ID_FACEBOOK,
+  VENDOR_ID_INSTAGRAM,
+  VENDOR_ID_TWITTER,
+  VENDOR_ID_YOUTUBE,
+} from '../../../vendor-mapping';
+import { PostCustomConsentPayload } from '../../../sourcepoint/typings';
 
 type Props = {
   privacyManagerId: number;
@@ -75,13 +82,18 @@ type Data = {
 export default Vue.extend<Data, {}, {}, Props>({
   name: 'EmbedPlaceholder',
   components: { PrivacyManager, ConsentActions },
-  data: () => ({
-    socialPurposeId: PURPOSE_ID_SOCIAL,
-  }),
   props: {
     privacyManagerId: {
       type: Number,
       required: true,
+    },
+  },
+  methods: {
+    getCustomConsentPayload(): PostCustomConsentPayload {
+      return {
+        purposeIds: [PURPOSE_ID_SOCIAL],
+        vendorIds: [VENDOR_ID_FACEBOOK, VENDOR_ID_INSTAGRAM, VENDOR_ID_TWITTER, VENDOR_ID_YOUTUBE],
+      };
     },
   },
 });


### PR DESCRIPTION
Implement a new method `customConsent` that can be used to give consents to vendors and purposes at once.