### PR TITLE
Use the newly implemented method `customConsent` in social-sharing-popup component

### DIFF
--- a/src/vue/components/EmbedPlaceholder/EmbedPlaceholder.test.ts
+++ b/src/vue/components/EmbedPlaceholder/EmbedPlaceholder.test.ts
@@ -1,13 +1,7 @@
 import Vue from 'vue';
 import { mount } from '@vue/test-utils';
 import { EmbedPlaceholder } from './';
-import {
-  PURPOSE_ID_SOCIAL,
-  VENDOR_ID_FACEBOOK,
-  VENDOR_ID_INSTAGRAM,
-  VENDOR_ID_TWITTER,
-  VENDOR_ID_YOUTUBE,
-} from '../../../vendor-mapping';
+import { getRelations, PURPOSE_ID_SOCIAL } from '../../../vendor-mapping';
 
 const loadPrivacyManagerModal = jest.fn();
 
@@ -57,8 +51,8 @@ describe('EmbedPlaceholder', () => {
     wrapper.find('.embed-placeholder__button').trigger('click');
 
     expect(customConsent).toHaveBeenCalledWith({
-      vendorIds: [VENDOR_ID_FACEBOOK, VENDOR_ID_INSTAGRAM, VENDOR_ID_TWITTER, VENDOR_ID_YOUTUBE],
       purposeIds: [PURPOSE_ID_SOCIAL],
+      vendorIds: getRelations(PURPOSE_ID_SOCIAL),
     });
   });
 

--- a/src/vue/components/EmbedPlaceholder/EmbedPlaceholder.vue
+++ b/src/vue/components/EmbedPlaceholder/EmbedPlaceholder.vue
@@ -62,13 +62,7 @@
 import Vue from 'vue';
 import { PrivacyManager } from '../PrivacyManager';
 import { ConsentActions } from '../ConsentActions';
-import {
-  PURPOSE_ID_SOCIAL,
-  VENDOR_ID_FACEBOOK,
-  VENDOR_ID_INSTAGRAM,
-  VENDOR_ID_TWITTER,
-  VENDOR_ID_YOUTUBE,
-} from '../../../vendor-mapping';
+import { PURPOSE_ID_SOCIAL, getRelations } from '../../../vendor-mapping';
 import { PostCustomConsentPayload } from '../../../sourcepoint/typings';
 
 type Props = {
@@ -85,7 +79,7 @@ export default Vue.extend<Data, {}, {}, Props>({
   data: () => ({
     customConsents: {
       purposeIds: [PURPOSE_ID_SOCIAL],
-      vendorIds: [VENDOR_ID_FACEBOOK, VENDOR_ID_INSTAGRAM, VENDOR_ID_TWITTER, VENDOR_ID_YOUTUBE],
+      vendorIds: getRelations(PURPOSE_ID_SOCIAL),
     },
   }),
   props: {

--- a/src/vue/components/SocialSharingPopup/SocialSharingPopup.test.ts
+++ b/src/vue/components/SocialSharingPopup/SocialSharingPopup.test.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import { mount } from '@vue/test-utils';
 import { SocialSharingPopup } from './';
-import { PURPOSE_ID_SOCIAL } from '../../../vendor-mapping';
+import { getRelations, PURPOSE_ID_SOCIAL } from '../../../vendor-mapping';
 
 const loadPrivacyManagerModal = jest.fn();
 
@@ -17,7 +17,7 @@ const privacyManagerStub = Vue.extend({
   },
 });
 
-const consentCustomPurpose = jest.fn();
+const customConsent = jest.fn();
 
 const consentActionsStub = Vue.extend({
   name: 'ConsentActions',
@@ -25,7 +25,7 @@ const consentActionsStub = Vue.extend({
     return (
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       this.$scopedSlots.default!({
-        consentCustomPurpose,
+        customConsent,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       }) as any
     );
@@ -75,6 +75,9 @@ describe('SocialSharingPopup', () => {
 
     wrapper.find('.social-sharing-popup__button--accept').trigger('click');
 
-    expect(consentCustomPurpose).toHaveBeenCalledWith(PURPOSE_ID_SOCIAL);
+    expect(customConsent).toHaveBeenCalledWith({
+      purposeIds: [PURPOSE_ID_SOCIAL],
+      vendorIds: getRelations(PURPOSE_ID_SOCIAL),
+    });
   });
 });

--- a/src/vue/components/SocialSharingPopup/SocialSharingPopup.vue
+++ b/src/vue/components/SocialSharingPopup/SocialSharingPopup.vue
@@ -22,10 +22,10 @@
           >
             Schließen
           </button>
-          <consent-actions v-slot="{ consentCustomPurpose }">
+          <consent-actions v-slot="{ customConsent }">
             <button
               class="social-sharing-popup__button social-sharing-popup__button--accept"
-              @click.prevent="[consentCustomPurpose(socialPurposeId), $emit('close')]"
+              @click.prevent="[customConsent(customConsents), $emit('close')]"
             >
               Akzeptieren
             </button>
@@ -40,10 +40,11 @@
 import Vue, { PropType } from 'vue';
 import { PrivacyManager } from '../PrivacyManager';
 import { ConsentActions } from '../ConsentActions';
-import { PURPOSE_ID_SOCIAL } from '../../../vendor-mapping';
+import { getRelations, PURPOSE_ID_SOCIAL } from '../../../vendor-mapping';
+import { PostCustomConsentPayload } from '../../../sourcepoint/typings';
 
 type Data = {
-  socialPurposeId: string;
+  customConsents: PostCustomConsentPayload;
 };
 
 type Props = {
@@ -53,11 +54,12 @@ type Props = {
 export default Vue.extend<Data, {}, {}, Props>({
   name: 'SocialSharingPopup',
   components: { PrivacyManager, ConsentActions },
-  data(): { socialPurposeId: string } {
-    return {
-      socialPurposeId: PURPOSE_ID_SOCIAL,
-    };
-  },
+  data: () => ({
+    customConsents: {
+      purposeIds: [PURPOSE_ID_SOCIAL],
+      vendorIds: getRelations(PURPOSE_ID_SOCIAL),
+    },
+  }),
   props: {
     privacyManagerId: {
       type: Number as PropType<number>,


### PR DESCRIPTION
Updates the social-sharing-popup component to use the newly implemented customConsent method.