### PR TITLE
fix(oembed): Regex adjustment 

### DIFF
--- a/src/embed-utils/oembed.test.ts
+++ b/src/embed-utils/oembed.test.ts
@@ -4,12 +4,12 @@ describe('oembed utilities', () => {
   describe('getScriptSrcFromOembedHTML', () => {
     it.each([
       ['script.js', '<script async src="script.js"></script>'],
-      ['script.js', '<script async src="script.js"/>'],
+      ['script.js', '<script src="script.js"/>'],
       ['script.js', '<script async src=" script.js "></script>'],
       ['script.js', '<script async src= " script.js "></script>'],
       ['script.js', `<script async src='script.js'></script>`],
+      ['script.js', '<script class="someClassName" data-configuration="someConfiguration" src="script.js"/>'],
       [null, `<scrip async src='script.js'></scrip>`],
-      [null, '<script src="script.js"></script>'],
       [null, ''],
     ])('should return %s for input: %s', (expected, input) => {
       expect(getScriptSrcFromOembedHTML(input)).toBe(expected);

--- a/src/embed-utils/oembed.ts
+++ b/src/embed-utils/oembed.ts
@@ -1,5 +1,5 @@
 export const getScriptSrcFromOembedHTML = (html: string): string | null => {
-  const src = html.match(/script async src\s*=\s*["'](.+?)["']/);
+  const src = html.match(/script(.*)src\s*=\s*["'](.+?)["']/);
 
-  return src ? src[1].trim() : null;
+  return src ? src[src.length - 1].trim() : null;
 };

--- a/src/embed-utils/oembed.ts
+++ b/src/embed-utils/oembed.ts
@@ -1,5 +1,5 @@
 export const getScriptSrcFromOembedHTML = (html: string): string | null => {
-  const src = html.match(/script(.*)src\s*=\s*["'](.+?)["']/);
+  const src = html.match(/script(?:.*)src\s*=\s*["'](.+?)["']/);
 
-  return src ? src[src.length - 1].trim() : null;
+  return src ? src[1].trim() : null;
 };


### PR DESCRIPTION
allow any string between script and src and remove async.

* Async is not necessary since, we will always add it when we create our own script element.

* Since some providers include various classes and data attributes on their provided scripts, we need to allow those within our regex.